### PR TITLE
Resolves issue #17 and #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,115 @@ $ npm run serve
 For `windows` run the command
 
 ```
-$ npm run startWindows
+$ npm run serveWindows
 ```
 
 > The server runs on port 80 in production.
 
-### Testing
+## The GraphQL API
 
-#### Mocha
+### Writing queries
+The graphQL API can be accessed by under the path `/`. The `query` is contained in the query-string
+of the request.
+
+```
+/?query={hello}
+```
+
+### GraphiQL
+
+In addition, you can also use [GraphiQL](https://github.com/graphql/graphiql) for
+ writing queries in an IDE environment. GraphiQL can be accessed using the URL path `/graphiql`
+
+ ```
+/graphiql
+ ```
+
+### Errors in execution of queries
+
+Any errors that occurs during the execution of a graphql query are contained in the response object under the key `"errors"`.
+
+The **structure of the error object differs depending on the environment that the server is run in**: production or development.
+
+#### Errors in development
+
+When running the server in development the error object has 3 properties: 
+
+* `"message"`: An explanation of the error that occurred
+* `"stack"`: The stacktrace of the error. This is very useful when debugging!
+* `"locations"`: An object that contains the `line` and the `column` associated with the graphql query where the execution error occurred.
+
+```js
+{
+  "errors": [{
+  	"message": string,
+  	"stack": [ string ],
+  	"locations": [{
+  		"line": number,
+  		"column": number
+  	}]
+  }]
+}
+```
+
+**Example: graphql error in development** 
+
+```js
+{
+  "errors": [
+    {
+      "message": "Some error occurred",
+      "stack": [
+        "Error: Unable to access database",
+        "    at resolve (index.js:42:17)",
+        "    at resolveOrError (/node_modules/graphql/execution/execute.js:447:12)",
+        "    at resolveField (/node_modules/graphql/execution/execute.js:438:16)",
+        "    at /node_modules/graphql/execution/execute.js:245:18",
+        "    at Array.reduce (native)",
+        "    at executeFields (/node_modules/graphql/execution/execute.js:242:42)"
+      ],
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Errors in production
+
+When running the server in production the error object only contains the error `"message"`.
+
+When running the server in production any errors that occur during the execution of the graphql query will be shown in the response error object that is found under the key "errors" in the graphql response.
+
+The array of object for the key `"errors"` contains all the errors that have occurred. 
+
+```js
+{
+  "errors": [{
+    "message": string		
+  }]
+}
+```
+
+**Example: graphql error in production**
+
+```js
+{
+  "errors":[
+    {
+       "message": "Some error occurred"
+    }
+  ]
+}
+```
+
+## Testing
+
+### Mocha
 
 All the tests are performed using `mocha` and assertions are made using `chai`. Tests are located in folders
 under the name `__tests__`.
@@ -81,7 +182,7 @@ Run the `mocha` tests using the command
 $ npm run test
 ```
 
-#### Flow
+### Flow
 
 This project includes the static type checking tool [Flow](https://flowtype.org/). Add `// @flow`
 at top of any file that you want `flow` to check.
@@ -92,7 +193,7 @@ Run the `flow` type check using the command
 $ npm run check
 ```
 
-#### Linting
+### Linting
 
 The library [standard](http://standardjs.com/) is used for linting the code. 
 
@@ -101,25 +202,3 @@ To check that all the code has been linted correctly run the following command
 ```
 $ npm run lint
 ```
-
-## The GraphQL API
-
-> The examples queries below assume that the server is running in development on port 3000.
-
-### Writing queries
-The graphQL API can be accessed by under the path `/`. The `query` is contained in the query-string
-of the request.
-
-```
-http://localhost:3000/?query={hello}
-```
-
-### GraphiQL
-
-In addition, you can also use [GraphiQL](https://github.com/graphql/graphiql) for
- writing queries in an IDE environment. GraphiQL can be accessed using the URL path `/graphiql`
-
- ```
-http://localhost:3000/graphiql
- ```
-

--- a/src/index.js
+++ b/src/index.js
@@ -14,38 +14,52 @@ import express from 'express'
 import graphqlHTTP from 'express-graphql'
 import schema from './graphQL'
 const app = express()
+import { GraphQLError } from 'graphql/error'
+
+const environment = process.env.NODE_ENV
+
+var port: number
+var errorFormatter
+
+switch (environment) {
+  case 'production':
+    port = 80
+    errorFormatter = (error: GraphQLError) => ({
+      message: error.message
+    })
+    break
+  case 'development':
+    port = 3000
+    errorFormatter = (error: GraphQLError) => ({
+      message: error.message,
+      stack: error.stack.split('\n'),
+      locations: error.locations
+    })
+    break
+  default:
+    throw new Error(`Unrecognized environment ${environment}`)
+}
 
 /**
  * The GraphiQL endpoint
  */
 app.use(`/graphiql`, graphqlHTTP(req => ({
   schema: schema,
-  graphiql: true
+  graphiql: true,
+  formatError: errorFormatter
 })
 ))
 
 /**
- * The single GraphQL Endpoint
+ * The GraphQL Endpoint
  */
 app.use('/', graphqlHTTP(req => ({
   schema: schema,
-  graphiql: false
+  graphiql: false,
+  pretty: environment !== 'production',
+  formatError: errorFormatter
 })
 ))
-
-const environment = process.env.NODE_ENV
-
-var port
-switch (environment) {
-  case 'production':
-    port = 80
-    break
-  case 'development':
-    port = 3000
-    break
-  default:
-    throw new Error(`Unrecognized environment ${environment}`)
-}
 
 app.listen(port, function () {
   console.log(`Server running on port ${port}`)


### PR DESCRIPTION
* Added formatted errors to the graphQL response. In development the graphql error now shows the entire stacktrace. In production, only the error message is shown.
* Fixed typo in the README. Command now correctly says `serveWindows` instead of `startWindows`.
* The JSON response sent by graphQL is now pretty printed when running in development.